### PR TITLE
v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ where you would typically write `puts …` or `pp …`, but with a few extras.
 
 2. Run `shards install`
 
+3. Make sure you compile your program with ENV variable `DEBUG` set to `1`
+  (for instance `DEBUG=1 shards build`). Otherwise all `debug!(…)` calls
+  will become a no-op.
+
+4. Once your program is compiled, you need to pass `DEBUG=1` again on the
+  program start, in order to activate `debug!(…)` logging. Alternatively,
+  you can call `Debug.enabled = true` within your code to achieve the same
+  behaviour.
+
 ## Usage
 
 ```crystal
@@ -60,14 +69,6 @@ The code above produces this output:
 ![debug!(…) macro output](https://i.imgur.com/tn0WnEL.png)
 
 ## Configuration
-
-- Make sure you compile your program with ENV variable `DEBUG` set to `1`
-  (for instance `DEBUG=1 shards build`). Otherwise all `debug!(…)` calls
-  will become a no-op.
-- Once your program is compiled, you need to pass `DEBUG=1` again on the
-  program start, in order to activate `debug!(…)` logging. Alternatively,
-  you can call `Debug.enabled = true` within your code to achieve the same
-  behaviour.
 
 You can change the global defaults by calling `Debug.configure` with a block:
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,11 @@ global defaults related to the logging itself.
 
 ```crystal
 Debug::Logger.configure do |settings|
+  settings.progname = "foo.cr"
+
   settings.show_severity = false
   settings.show_datetime = true
+  settings.show_progname = true
 
   settings.colors[:datetime] = :dark_gray
   settings.colors[:progname] = :light_blue

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: debug
-version: 1.0.0
+version: 1.1.0
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/spec/debug/to_debug/object.cr
+++ b/spec/debug/to_debug/object.cr
@@ -1,0 +1,40 @@
+require "../../spec_helper"
+
+class FooToDebug
+  def initialize(@bar : String); end
+end
+
+describe Debug do
+  context "Object#to_debug" do
+    it "works for Value-s" do
+      true.to_debug.should contain "true"
+      :foo.to_debug.should contain ":foo"
+      438006.to_debug.should contain "438006"
+    end
+
+    it "works for Reference-s" do
+      # class name
+      FooToDebug.new("baz").to_debug.should contain "Foo"
+      # ivar name
+      FooToDebug.new("baz").to_debug.should contain "bar"
+      # ivar value
+      FooToDebug.new("baz").to_debug.should contain "baz"
+    end
+  end
+
+  context "Object#to_debug(IO)" do
+    it "works for Value-s" do
+      str = String.build do |io|
+        :foo.to_debug(io).should be_nil
+      end
+      str.should contain ":foo"
+    end
+
+    it "works for Reference-s" do
+      str = String.build do |io|
+        FooToDebug.new("whatever").to_debug(io)
+      end
+      str.should contain "whatever"
+    end
+  end
+end

--- a/spec/debug_spec.cr
+++ b/spec/debug_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "./debug/**"
 
 class Foo
 end

--- a/src/debug.cr
+++ b/src/debug.cr
@@ -89,11 +89,17 @@ module Debug
                 end
               end
 
+              %str << '\n' if %exp['\n']?
               %str << %exp
                 .colorize(%colors[:expression])
+
               %str << " = "
                 .colorize(%colors[:decorator])
-              %val.to_debug(%str)
+
+              %val.to_debug.tap do |%pretty_val|
+                %str << '\n' if %pretty_val['\n']?
+                %str << %pretty_val
+              end
               %str << " (" << typeof(%val).to_s.colorize(%colors[:type]) << ')'
             end
 

--- a/src/debug/logger/settings.cr
+++ b/src/debug/logger/settings.cr
@@ -1,5 +1,16 @@
 class Debug::Logger
   class Settings
+    private module LoggerDelegators
+      delegate :logger, :logger=, to: Debug
+      delegate :level, :progname, :progname=, to: :logger
+
+      def level=(level : ::Logger::Severity)
+        logger.level = level
+      end
+    end
+
+    extend LoggerDelegators
+
     class_property? show_severity : Bool = true
     class_property? show_datetime : Bool = false
     class_property? show_progname : Bool = true

--- a/src/debug/to_debug/object.cr
+++ b/src/debug/to_debug/object.cr
@@ -6,6 +6,7 @@ class Object
   end
 
   def to_debug : String
-    String.build &->to_debug(IO)
+    # https://github.com/crystal-lang/crystal/issues/8198
+    String.build { |io| to_debug(io) }
   end
 end

--- a/src/debug/version.cr
+++ b/src/debug/version.cr
@@ -1,3 +1,3 @@
 module Debug
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
- Prepend multiline expressions and values with extra newline for readability
- Support setting `logger` and its properties (`level`, `progname`) properties through `Debug::Logger.settings`
- Fix `Object#to_debug` triggering Crystal ICE (see https://github.com/crystal-lang/crystal/issues/8198)