### PR TITLE
v2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ crystal:
   - latest
   - nightly
 
-matrix:
+jobs:
   allow_failures:
     - crystal: nightly
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,9 @@ global defaults related to the logging itself.
 
 ```crystal
 Debug::Logger.configure do |settings|
-  settings.progname = "foo.cr"
-
   settings.show_severity = false
   settings.show_datetime = true
-  settings.show_progname = true
+  settings.show_progname = false
 
   settings.colors[:datetime] = :dark_gray
   settings.colors[:progname] = :light_blue

--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ global defaults related to the logging itself.
 
 ```crystal
 Debug::Logger.configure do |settings|
+  settings.progname = "foo.cr"
+
   settings.show_severity = false
   settings.show_datetime = true
-  settings.show_progname = false
+  settings.show_progname = true
 
   settings.colors[:datetime] = :dark_gray
   settings.colors[:progname] = :light_blue

--- a/shard.yml
+++ b/shard.yml
@@ -7,7 +7,7 @@ authors:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.10.0
+    version: ~> 0.13.0
 
 crystal: 0.35.0
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: debug
-version: 1.1.0
+version: 2.0.0-dev
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: debug
-version: 2.0.0-dev
+version: 2.0.0
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/shard.yml
+++ b/shard.yml
@@ -9,6 +9,6 @@ development_dependencies:
     github: crystal-ameba/ameba
     version: ~> 0.10.0
 
-crystal: 0.30.1
+crystal: 0.35.0
 
 license: MIT

--- a/spec/debug_spec.cr
+++ b/spec/debug_spec.cr
@@ -13,7 +13,51 @@ enum Baz
   Three
 end
 
+ENV_DEBUG_KEY = "DEBUG"
+
 describe Debug do
+  describe ".enabled?" do
+    it "should be true when ENV debug key is set to '1'" do
+      previous_env = ENV[ENV_DEBUG_KEY]?
+      begin
+        ENV[ENV_DEBUG_KEY] = "1"
+        Debug.enabled?.should be_true
+      ensure
+        ENV[ENV_DEBUG_KEY] = previous_env
+      end
+    end
+
+    it "should be false when ENV debug key is set to value other than '1'" do
+      previous_env = ENV[ENV_DEBUG_KEY]?
+      begin
+        ENV[ENV_DEBUG_KEY] = "10"
+        Debug.enabled?.should be_false
+      ensure
+        ENV[ENV_DEBUG_KEY] = previous_env
+      end
+    end
+
+    it "should be false when ENV debug key is unset" do
+      previous_env = ENV.delete(ENV_DEBUG_KEY)
+      begin
+        Debug.enabled?.should be_false
+      ensure
+        ENV[ENV_DEBUG_KEY] = previous_env
+      end
+    end
+
+    it "setting explicit (non-nil) value should have priority over ENV" do
+      previous_env = ENV.delete(ENV_DEBUG_KEY)
+      begin
+        Debug.enabled = true
+        Debug.enabled?.should be_true
+      ensure
+        ENV[ENV_DEBUG_KEY] = previous_env
+        Debug.enabled = nil
+      end
+    end
+  end
+
   context "with literals" do
     it "works with Nil" do
       assert_debug nil

--- a/spec/debug_spec.cr
+++ b/spec/debug_spec.cr
@@ -58,6 +58,33 @@ describe Debug do
     end
   end
 
+  it "passes :severity as Log::Entry#severity" do
+    next unless Debug.enabled?
+
+    ::Log.capture do |logs|
+      debug!("foo")
+      debug!("bar", severity: :trace)
+
+      logs.check :debug, /foo/
+      logs.next :trace, /bar/
+    end
+  end
+
+  it "passes :progname into Log::Entry#data" do
+    next unless Debug.enabled?
+
+    progname = "bar.cr"
+
+    ::Log.capture do |logs|
+      debug!("foo", progname: progname)
+
+      logs.check :debug, /foo/
+
+      entry = logs.entry?.should_not be_nil
+      entry.data[:progname]?.should eq(progname)
+    end
+  end
+
   context "with literals" do
     it "works with Nil" do
       assert_debug nil

--- a/src/debug.cr
+++ b/src/debug.cr
@@ -42,67 +42,67 @@ module Debug
           %colors = %settings.colors
 
           {% for arg, i in args %}
-            %exp, %val =
-              %arg_expressions[{{ i }}], %arg_values[{{ i }}]
+            ::Debug.logger.{{ severity.id }} do
+              %exp, %val =
+                %arg_expressions[{{ i }}], %arg_values[{{ i }}]
 
-            %str = String.build do |%str|
-              case %settings.location_detection
-              when .compile?
-                %relative_path = Path[{{ file }}].relative_to(Dir.current).to_s
-                if %relative_path
-                  if %max_path_length = %settings.max_path_length
-                    if %relative_path.size > %max_path_length
-                      %relative_path = "…" + %relative_path[-%max_path_length..]
+              String.build do |%str|
+                case %settings.location_detection
+                when .compile?
+                  %relative_path = Path[{{ file }}].relative_to(Dir.current).to_s
+                  if %relative_path
+                    if %max_path_length = %settings.max_path_length
+                      if %relative_path.size > %max_path_length
+                        %relative_path = "…" + %relative_path[-%max_path_length..]
+                      end
                     end
+                    %str << "#{%relative_path}:{{ line }}"
+                      .colorize(%colors[:path])
                   end
-                  %str << "#{%relative_path}:{{ line }}"
-                    .colorize(%colors[:path])
-                end
 
-                %def_name = {{ @def && @def.name.stringify }}
-                if %def_name
-                  %str << " (#{%def_name})"
-                    .colorize(%colors[:method])
-                end
-                %str << " -- "
+                  %def_name = {{ @def && @def.name.stringify }}
+                  if %def_name
+                    %str << " (#{%def_name})"
+                      .colorize(%colors[:method])
+                  end
+                  %str << " -- "
 
-              when .runtime?
-                %DEBUG_CALLER_PATTERN = /caller:Array\(String\)/i
-                %caller_list = caller
+                when .runtime?
+                  %DEBUG_CALLER_PATTERN = /caller:Array\(String\)/i
+                  %caller_list = caller
 
-                if %caller_list.any?(&.match(%DEBUG_CALLER_PATTERN))
-                  while !%caller_list.empty? && %caller_list.first? !~ %DEBUG_CALLER_PATTERN
+                  if %caller_list.any?(&.match(%DEBUG_CALLER_PATTERN))
+                    while !%caller_list.empty? && %caller_list.first? !~ %DEBUG_CALLER_PATTERN
+                      %caller_list.shift?
+                    end
                     %caller_list.shift?
                   end
-                  %caller_list.shift?
+
+                  {% if backtrace_offset > 0 %}
+                    %caller_list.shift({{ backtrace_offset }})
+                  {% end %}
+
+                  if %caller = %caller_list.first?
+                    %str << %caller
+                      .colorize(%colors[:method])
+                    %str << " -- "
+                  end
                 end
 
-                {% if backtrace_offset > 0 %}
-                  %caller_list.shift({{ backtrace_offset }})
-                {% end %}
+                %str << '\n' if %exp['\n']?
+                %str << %exp
+                  .colorize(%colors[:expression])
 
-                if %caller = %caller_list.first?
-                  %str << %caller
-                    .colorize(%colors[:method])
-                  %str << " -- "
+                %str << " = "
+                  .colorize(%colors[:decorator])
+
+                %val.to_debug.tap do |%pretty_val|
+                  %str << '\n' if %pretty_val['\n']?
+                  %str << %pretty_val
                 end
+                %str << " (" << typeof(%val).to_s.colorize(%colors[:type]) << ')'
               end
-
-              %str << '\n' if %exp['\n']?
-              %str << %exp
-                .colorize(%colors[:expression])
-
-              %str << " = "
-                .colorize(%colors[:decorator])
-
-              %val.to_debug.tap do |%pretty_val|
-                %str << '\n' if %pretty_val['\n']?
-                %str << %pretty_val
-              end
-              %str << " (" << typeof(%val).to_s.colorize(%colors[:type]) << ')'
             end
-
-            ::Debug.logger.{{ severity.id }} { %str }
           {% end %}
         end
       {% end %}

--- a/src/debug.cr
+++ b/src/debug.cr
@@ -1,4 +1,4 @@
-require "logger"
+require "log"
 require "colorize"
 
 module Debug
@@ -18,8 +18,7 @@ module Debug
   end
 
   macro log(*args,
-            severity = Logger::Severity::DEBUG,
-            progname = nil,
+            severity = :debug,
             backtrace_offset = 0,
             file = __FILE__,
             line = __LINE__)
@@ -49,14 +48,14 @@ module Debug
             %str = String.build do |%str|
               case %settings.location_detection
               when .compile?
-                %relative_filepath = {{ file }}.lchop(Dir.current + "/")
-                if %relative_filepath
+                %relative_path = Path[{{ file }}].relative_to(Dir.current).to_s
+                if %relative_path
                   if %max_path_length = %settings.max_path_length
-                    if %relative_filepath.size > %max_path_length
-                      %relative_filepath = "…" + %relative_filepath[-%max_path_length..]
+                    if %relative_path.size > %max_path_length
+                      %relative_path = "…" + %relative_path[-%max_path_length..]
                     end
                   end
-                  %str << "#{%relative_filepath}:{{ line }}"
+                  %str << "#{%relative_path}:{{ line }}"
                     .colorize(%colors[:path])
                 end
 
@@ -103,7 +102,7 @@ module Debug
               %str << " (" << typeof(%val).to_s.colorize(%colors[:type]) << ')'
             end
 
-            ::Debug.logger.log({{ severity }}, %str, {{ progname }})
+            ::Debug.logger.{{ severity.id }} { %str }
           {% end %}
         end
       {% end %}

--- a/src/debug.cr
+++ b/src/debug.cr
@@ -19,6 +19,7 @@ module Debug
 
   macro log(*args,
             severity = :debug,
+            progname = nil,
             backtrace_offset = 0,
             file = __FILE__,
             line = __LINE__)
@@ -42,11 +43,11 @@ module Debug
           %colors = %settings.colors
 
           {% for arg, i in args %}
-            ::Debug.logger.{{ severity.id }} do
+            ::Debug.logger.{{ severity.id }} do |%emitter|
               %exp, %val =
                 %arg_expressions[{{ i }}], %arg_values[{{ i }}]
 
-              String.build do |%str|
+              %ret = String.build do |%str|
                 case %settings.location_detection
                 when .compile?
                   %relative_path = Path[{{ file }}].relative_to(Dir.current).to_s
@@ -102,6 +103,8 @@ module Debug
                 end
                 %str << " (" << typeof(%val).to_s.colorize(%colors[:type]) << ')'
               end
+
+              %emitter.emit(%ret, progname: {{ progname }})
             end
           {% end %}
         end

--- a/src/debug/logger.cr
+++ b/src/debug/logger.cr
@@ -1,31 +1,30 @@
 module Debug
-  class Logger < ::Logger
-    private DEFAULT_FORMATTER = Formatter.new do |severity, datetime, progname, message, io|
-      parts = [] of String | Colorize::Object(String)
+  private DEFAULT_FORMATTER = Log::Formatter.new do |entry, io|
+    parts = [] of String | Colorize::Object(String)
 
-      Logger.settings.tap do |settings|
-        if settings.show_severity?
-          parts << severity.to_s.rjust(5).colorize(settings.severity_colors[severity])
-        end
-        if settings.show_datetime?
-          parts << "[#{datetime.to_s.colorize(settings.colors[:datetime])}]"
-        end
-        if settings.show_progname? && !progname.empty?
-          parts << "[#{progname.colorize(settings.colors[:progname])}]"
-        end
-        unless parts.empty?
-          io.tap { parts.join(' ', io) } << " -- "
-        end
-        io << message
+    Logger.settings.tap do |settings|
+      if settings.show_severity? && (severity = entry.severity)
+        parts << severity.label.to_s.rjust(6).colorize(settings.severity_colors[severity])
       end
-    end
-
-    def initialize(@io : IO?, @level = Severity::DEBUG, @formatter = DEFAULT_FORMATTER, @progname = "")
-      super
+      if settings.show_datetime? && (timestamp = entry.timestamp)
+        parts << "[#{timestamp.to_s.colorize(settings.colors[:datetime])}]"
+      end
+      if settings.show_progname? && (progname = Log.progname.presence)
+        parts << "[#{progname.colorize(settings.colors[:progname])}]"
+      end
+      unless parts.empty?
+        io.tap { parts.join(io, ' ') } << " -- "
+      end
+      io << entry.message
     end
   end
 
-  class_property logger : ::Logger { Logger.new(STDOUT) }
+  class_property logger : Log do
+    backend = Log::IOBackend.new(STDOUT, formatter: DEFAULT_FORMATTER)
+
+    Log.builder.bind("debug.*", :trace, backend)
+    Log.for("debug")
+  end
 end
 
 require "./logger/*"

--- a/src/debug/logger.cr
+++ b/src/debug/logger.cr
@@ -9,7 +9,8 @@ module Debug
       if settings.show_datetime? && (timestamp = entry.timestamp)
         parts << "[#{timestamp.to_s.colorize(settings.colors[:datetime])}]"
       end
-      if settings.show_progname? && (progname = Log.progname.presence)
+      progname = entry.data[:progname]?.try(&.as_s?) || settings.progname
+      if settings.show_progname? && progname.presence
         parts << "[#{progname.colorize(settings.colors[:progname])}]"
       end
       unless parts.empty?

--- a/src/debug/logger/settings.cr
+++ b/src/debug/logger/settings.cr
@@ -13,7 +13,9 @@ class Debug::Logger
 
     class_property? show_severity = true
     class_property? show_datetime = false
-    class_property? show_progname = false
+    class_property? show_progname = true
+
+    class_property progname : String?
 
     class_getter colors = {
       :datetime => :dark_gray,

--- a/src/debug/logger/settings.cr
+++ b/src/debug/logger/settings.cr
@@ -2,18 +2,18 @@ class Debug::Logger
   class Settings
     private module LoggerDelegators
       delegate :logger, :logger=, to: Debug
-      delegate :level, :progname, :progname=, to: :logger
+      delegate :level, to: :logger
 
-      def level=(level : ::Logger::Severity)
+      def level=(level : Log::Severity)
         logger.level = level
       end
     end
 
     extend LoggerDelegators
 
-    class_property? show_severity : Bool = true
-    class_property? show_datetime : Bool = false
-    class_property? show_progname : Bool = true
+    class_property? show_severity = true
+    class_property? show_datetime = false
+    class_property? show_progname = false
 
     class_getter colors = {
       :datetime => :dark_gray,
@@ -21,13 +21,14 @@ class Debug::Logger
     } of Symbol => Colorize::Color
 
     class_getter severity_colors = {
-      :unknown => :dark_gray,
-      :error   => :red,
-      :warn    => :light_red,
-      :info    => :blue,
-      :debug   => :green,
-      :fatal   => :magenta,
-    } of Logger::Severity => Colorize::Color
+      :trace  => :white,
+      :debug  => :green,
+      :info   => :blue,
+      :notice => :dark_gray,
+      :warn   => :light_red,
+      :error  => :red,
+      :fatal  => :magenta,
+    } of Log::Severity => Colorize::Color
   end
 
   class_getter settings = Settings

--- a/src/debug/to_debug/object.cr
+++ b/src/debug/to_debug/object.cr
@@ -1,9 +1,5 @@
 class Object
-  def to_debug(io) : Nil
-    io << self
-      .pretty_inspect(indent: 2)
-      .colorize(Debug.settings.colors[:value])
-  end
+  abstract def to_debug(io) : Nil
 
   def to_debug : String
     # https://github.com/crystal-lang/crystal/issues/8198

--- a/src/debug/to_debug/reference.cr
+++ b/src/debug/to_debug/reference.cr
@@ -1,0 +1,9 @@
+class Reference
+  def to_debug(io) : Nil
+    colors = Debug.settings.colors
+
+    io << self
+      .pretty_inspect(indent: 2)
+      .colorize(colors[:value])
+  end
+end

--- a/src/debug/to_debug/value.cr
+++ b/src/debug/to_debug/value.cr
@@ -1,0 +1,9 @@
+struct Value
+  def to_debug(io) : Nil
+    colors = Debug.settings.colors
+
+    io << self
+      .pretty_inspect(indent: 2)
+      .colorize(colors[:value])
+  end
+end


### PR DESCRIPTION
- Switched from obsolete `Logger` to `Log`, fixes #2
- `Object#to_debug(io)` is now an abstract method
- Expanded spec coverage a bit
- Bumped ameba version to `~> 0.13`