### PR TITLE
Proposed changes/additions extracted from how I patched this library for use with the Crystal OpenTelemetry project

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -7,7 +7,7 @@ authors:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.0
+    version: ~> 1.0.0
 
 crystal: ">= 0.35.1"
 

--- a/spec/debug_spec.cr
+++ b/spec/debug_spec.cr
@@ -27,10 +27,26 @@ describe Debug do
       end
     end
 
-    it "should be false when ENV debug key is set to value other than '1'" do
+    it "should be true when ENV debug key is set to other shell-truthy values" do
       previous_env = ENV[ENV_DEBUG_KEY]?
       begin
-        ENV[ENV_DEBUG_KEY] = "10"
+        ENV[ENV_DEBUG_KEY] = "true"
+        Debug.enabled?.should be_true
+
+        ENV[ENV_DEBUG_KEY] = "123"
+        Debug.enabled?.should be_true
+      ensure
+        ENV[ENV_DEBUG_KEY] = previous_env
+      end
+    end
+
+    it "should be false when ENV debug key is set to value other shell-falsey values" do
+      previous_env = ENV[ENV_DEBUG_KEY]?
+      begin
+        ENV[ENV_DEBUG_KEY] = "false"
+        Debug.enabled?.should be_false
+
+        ENV[ENV_DEBUG_KEY] = ""
         Debug.enabled?.should be_false
       ensure
         ENV[ENV_DEBUG_KEY] = previous_env
@@ -83,6 +99,11 @@ describe Debug do
       entry = logs.entry?.should_not be_nil
       entry.data[:progname]?.should eq(progname)
     end
+  end
+
+  it "prints debug statements at the macro level" do
+    result = {{ system("./spec/macro_debug.sh").stringify }}
+    result.should match(/This is a message/)
   end
 
   context "with literals" do

--- a/spec/macro_debug.cr
+++ b/spec/macro_debug.cr
@@ -1,0 +1,3 @@
+require "../src/debug"
+
+macro_debug!("This is a message.")

--- a/spec/macro_debug.sh
+++ b/spec/macro_debug.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+crystal run -DDEBUG spec/macro_debug.cr

--- a/src/debug.cr
+++ b/src/debug.cr
@@ -3,19 +3,19 @@ require "colorize"
 
 module Debug
   {% begin %}
-    ACTIVE = {{ env("DEBUG") == "1" }}
-  {% end %}
+    ACTIVE = {{ flag?(:DEBUG) || (env("DEBUG") && env("DEBUG") != "0" && env("DEBUG") != "false" && env("DEBUG") != "") }}
 
-  class_property? enabled : Bool?
+    class_property? enabled : Bool?
 
-  def self.enabled? : Bool
-    case enabled = @@enabled
-    when Nil
-      ENV["DEBUG"]? == "1"
-    else
-      enabled
+    def self.enabled? : Bool
+      case enabled = @@enabled
+      when Nil
+        !!({{ flag?(:DEBUG) }} || (ENV["DEBUG"]? && ENV["DEBUG"] != "0" && ENV["DEBUG"] != "false" && ENV["DEBUG"].presence))
+      else
+        enabled
+      end
     end
-  end
+  {% end %}
 
   macro log(*args,
             severity = :debug,
@@ -119,4 +119,5 @@ module Debug
   end
 end
 
+require "./macro_debug"
 require "./debug/**"

--- a/src/macro_debug.cr
+++ b/src/macro_debug.cr
@@ -4,11 +4,11 @@ module Debug
   # codes, see this link:
   # [https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit)
   MDEBUG_COLORS = {
-    :severity => "82",
+    :severity  => "82",
     :separator => "230",
-    :file => "8",
-    :lineno => "8",
-    :message => "15"
+    :file      => "8",
+    :lineno    => "8",
+    :message   => "15",
   }
 end
 

--- a/src/macro_debug.cr
+++ b/src/macro_debug.cr
@@ -1,0 +1,39 @@
+module Debug
+  # This constant contains the colors used when highlighting macro
+  # debugging statements via `mdebug!`. For more information on these
+  # codes, see this link:
+  # [https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit)
+  MDEBUG_COLORS = {
+    :severity => "82",
+    :separator => "230",
+    :file => "8",
+    :lineno => "8",
+    :message => "15"
+  }
+end
+
+# This is the main macro level debugging statement. It takes a message, and
+# an optional severity level, and outputs, during macro evaluation, the
+# debugging statement, highlighted according to the color codes in the
+# `Debug::MDEBUG_COLORS` constant.
+#
+# If debugging is not active (either the `DEBUG` flag is not set, or the
+# `DEBUG` environment variable is not set to a truthy value), this macro
+# will do nothing.
+macro macro_debug!(message,
+                   severity = :debug,
+                   file = __FILE__,
+                   line = __LINE__)
+  {% if ::Debug::ACTIVE %}
+    \{%
+      puts [
+      "\e[38;5;{{ ::Debug::MDEBUG_COLORS[:severity].id }}m{{ severity.upcase.id }}\e[0m",
+      "\e[38;5;{{ ::Debug::MDEBUG_COLORS[:separator].id }}m -- \e[0m",
+      "\e[38;5;{{ ::Debug::MDEBUG_COLORS[:file].id }}m{{ file.id }}\e[0m",
+      "\e[38;5;{{ ::Debug::MDEBUG_COLORS[:separator].id }}m:\e[0m",
+      "\e[38;5;{{ ::Debug::MDEBUG_COLORS[:lineno].id }}m{{ line }}\e[0m",
+      "\e[38;5;{{ ::Debug::MDEBUG_COLORS[:separator].id }}m -- \e[0m",
+      "\e[38;5;{{ ::Debug::MDEBUG_COLORS[:message].id }}m{{ message.id }}\e[0m"].join("")
+    %}
+  {% end %}
+end


### PR DESCRIPTION
This change does a couple of things. It expands the allowable mechanisms to turn on debugging, so that the -DDEBUG flag, at compilation, also enables debugging. This allows one to build a binary that has debugging always enabled, regardless of ENV settings. It also establishes that any shell-truth value (not empty, not `0`, and not `false`) is an enabling value for the environment variable. i.e.

```bash
DEBUG=true my_crystal_program
```

is logically the same as

```base
DEBUG=1 my_crystal_program
```

In addition, it adds a `macro_debug!` macro that inserts _macro_ debugging code. For example:

```crystal
macro method_missing(call)
  macro_debug!("Method missing: {{ call.name }}")
  (raise NotImplementedError.new([{{ @type.id.stringify }}, "{{ call.name.id }} not implemented"].join("#")))
end
```

This will print a compile-time debugging message about the missing method, if debugging is enabled.

Both of these are extracted from the Crystal OpenTelemetry project, where I have included them as a substantial monkeypatch in order to use them for internal debugging.